### PR TITLE
ocoOrder error: stopPrice param is empty/null/malformed fix

### DIFF
--- a/php-binance-api.php
+++ b/php-binance-api.php
@@ -2987,7 +2987,7 @@ class API
             $error = "Parameter stopprice expected numeric for ' $side . ' ' . $symbol .', got " . gettype($stopprice);
             trigger_error($error, E_USER_ERROR);
         } else {
-            $opt['stopprice'] = $stopprice;
+            $opt['stopPrice'] = $stopprice;
         }
 
         if (is_null($stoplimitprice) === false && empty($stoplimitprice) === false) {


### PR DESCRIPTION
ocoOrder() with stopprice param was throwing an error that stopPrice param is empty or malformed so after changing it to "stopPrice" now it works.